### PR TITLE
Updated 1.1 rockspec to use correct URL for source tarball

### DIFF
--- a/rockspecs/tnetstrings-1.1.0-1.rockspec
+++ b/rockspecs/tnetstrings-1.1.0-1.rockspec
@@ -2,7 +2,7 @@ package = 'tnetstrings'
 version = '1.1.0-1'
 
 source = {
-    url = 'https://github.com/downloads/jsimmons/tnetstrings.lua/tnetstrings-1.1.0.tar.bz2';
+    url = 'http://cloud.github.com/downloads/jsimmons/tnetstrings.lua/tnetstrings-1.1.0.tar.bz2';
 }
 
 description = {


### PR DESCRIPTION
Use HTTP instead of HTTPS - luarocks doesn't support SSL 
Use direct link to source tarball - luarocks does not follow 302 redirects
